### PR TITLE
fixed remote code execution on ffmpeg-web-gui

### DIFF
--- a/upload-and-convert.php
+++ b/upload-and-convert.php
@@ -173,11 +173,11 @@ if (isset($_FILES) && $_FILES) {
 					if (isset($_POST['encoding_x264'])) {
 
 
-						$command = $ffmpegCommand.' -i '.$filePath.$file_uploaded.' -vcodec libx264  -vsync 1  -bt 50k ';
+						$command = escapeshellcmd($ffmpegCommand.' -i '.$filePath.$file_uploaded.' -vcodec libx264  -vsync 1  -bt 50k ');
 						if ($audioEnabled) {
 							$command = $command.' -acodec libfaac ';
 						}
-						$command = $command.$customParams.'  '.$filePath.$convertedLocation.$uploadedFilename.'_x264.mp4  2>&1';
+						$command = escapeshellcmd($command.$customParams.'  '.$filePath.$convertedLocation.$uploadedFilename.'_x264.mp4  2>&1');
 						exec($command, $output, $status);
 						$output = 'File: '.$file_uploaded."\n".implode("\n", $output);
 						// Log to file
@@ -188,7 +188,7 @@ if (isset($_FILES) && $_FILES) {
 						// This is a useful tool if you're showing your H.264 MP4 videos on the web.
 						// It relocates some data in the video to allow playback to begin before the file is completely downloaded.
 						// Usage: qt-faststart input.mp4 output.mp4.
-						$command = $qt_faststart.' '.$filePath.$convertedLocation.$uploadedFilename.'_x264.mp4 '.$filePath.$convertedLocation.$uploadedFilename.'_x264_qt_faststart.mp4  2>&1';
+						$command = escapeshellcmd($qt_faststart.' '.$filePath.$convertedLocation.$uploadedFilename.'_x264.mp4 '.$filePath.$convertedLocation.$uploadedFilename.'_x264_qt_faststart.mp4  2>&1');
 						exec($command, $output, $status);
 						$output = 'File: '.$file_uploaded."\n".implode("\n", $output);
 						// Log to file
@@ -203,7 +203,7 @@ if (isset($_FILES) && $_FILES) {
 						if ($audioEnabled) {
 							$command = $command.' -acodec libvorbis ';
 						}
-						$command = $command.$customParams.' '.$filePath.$convertedLocation.$uploadedFilename.'.ogv  2>&1';
+						$command = escapeshellcmd($command.$customParams.' '.$filePath.$convertedLocation.$uploadedFilename.'.ogv  2>&1');
 						exec($command, $output, $status);
 						$output = 'File: '.$file_uploaded."\n".implode("\n", $output);
 						// Log to file
@@ -213,7 +213,7 @@ if (isset($_FILES) && $_FILES) {
 
 					// Webm file
 					if (isset($_POST['encoding_webm'])) {
-						$command = $ffmpegCommand.' -i '.$filePath.$file_uploaded.$customParams.$filePath.$convertedLocation.$uploadedFilename.'.webm  2>&1';
+						$command = escapeshellcmd($ffmpegCommand.' -i '.$filePath.$file_uploaded.$customParams.$filePath.$convertedLocation.$uploadedFilename.'.webm  2>&1');
 						exec($command, $output, $status);
 						$output = 'File: '.$file_uploaded."\n".implode("\n", $output);
 						// Log to file
@@ -223,7 +223,7 @@ if (isset($_FILES) && $_FILES) {
 
 					// Screen shots
 					if (isset($_POST['encoding_stills'])) {
-						$command = $ffmpegCommand.' -i '.$filePath.$file_uploaded.' -s '.$videoSize.' -r 1 -vframes 5 -ss 00:01 -y '.$filePath.$convertedLocation.$uploadedFilename.'_stills_%d.png  2>&1';
+						$command = escapeshellcmd($ffmpegCommand.' -i '.$filePath.$file_uploaded.' -s '.$videoSize.' -r 1 -vframes 5 -ss 00:01 -y '.$filePath.$convertedLocation.$uploadedFilename.'_stills_%d.png  2>&1');
 						exec($command, $output, $status);
 						$output = 'File: '.$file_uploaded."\n".implode("\n", $output);
 						// Log to file


### PR DESCRIPTION
### 📊 Metadata *

Fixed remote code execution vulnerability during file upload.
#### Bounty URL:  https://www.huntr.dev/bounties/1-packagist-ffmpeg-web-gui

### ⚙️ Description *

The `ffmpeg-web-gui` project is a video converter written in PHP which uses the `ffmpeg` command to convert videos in HTML formats. The arbitrary command injection is due to unsafe command concatenation with user-supplied inputs which can be manipulated by an attacker and result in complete RCE on the server. 
https://www.php.net/manual/en/function.escapeshellcmd.php

### 💻 Technical Description *

The vulnerability exists due to unsanitized user-input passed to `exec()` command. This can be solved by using PHP's `escapeshellcmd()` which escapes any characters in a string that might be used to trick a shell command into executing arbitrary commands. Hence the issue is fixed.

### 🐛 Proof of Concept (PoC) *

*    Download the code of the project
*    Put it into a webserver root folder (I used Apache with /var/www/html/ffmpeg_web_gui)
*    Open http://localtest.me/ffmpeg_web_gui/upload-and-convert.php
*    Upload a valid mp4 file (I used these: https://file-examples-com.github.io/uploads/2017/04/file_example_MP4_480_1_5MG.mp4)
*    Intercept the request with Burp and change the filename into test;touch HACKED;#
*    The request will be like:
```
POST /ffmpeg_web_gui/upload-and-convert.php HTTP/1.1
Host: localtest.me
Content-Length: 1571624
Cache-Control: max-age=0
Origin: http://localtest.me
Upgrade-Insecure-Requests: 1
Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryMFH7A2ecHBQQMhZu
User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.162 Safari/537.36
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
Referer: http://localtest.me/ffmpeg_web_gui/upload-and-convert.php
Accept-Encoding: gzip, deflate
Accept-Language: en-US,en;q=0.9,it;q=0.8,ru;q=0.7
Connection: close

------WebKitFormBoundaryMFH7A2ecHBQQMhZu
Content-Disposition: form-data; name="file"; filename="test;touch HACKED;#.mp4"
Content-Type: video/mp4

<video_data_binary>
------WebKitFormBoundaryMFH7A2ecHBQQMhZu
Content-Disposition: form-data; name="video_size"

560x304
------WebKitFormBoundaryMFH7A2ecHBQQMhZu
Content-Disposition: form-data; name="video_bitrate"

700
------WebKitFormBoundaryMFH7A2ecHBQQMhZu
Content-Disposition: form-data; name="video_framerate"

30
------WebKitFormBoundaryMFH7A2ecHBQQMhZu
Content-Disposition: form-data; name="encoding_video_deinterlace"

on
------WebKitFormBoundaryMFH7A2ecHBQQMhZu
Content-Disposition: form-data; name="encoding_enable_audio"

on
------WebKitFormBoundaryMFH7A2ecHBQQMhZu
Content-Disposition: form-data; name="encoding_audio_sampling_rate"

44100
------WebKitFormBoundaryMFH7A2ecHBQQMhZu
Content-Disposition: form-data; name="encoding_audio_bitrate"

128
------WebKitFormBoundaryMFH7A2ecHBQQMhZu
Content-Disposition: form-data; name="encoding_audio_channels"

stereo
------WebKitFormBoundaryMFH7A2ecHBQQMhZu
Content-Disposition: form-data; name="encoding_x264"

on
------WebKitFormBoundaryMFH7A2ecHBQQMhZu
Content-Disposition: form-data; name="encoding_ogv"

on
------WebKitFormBoundaryMFH7A2ecHBQQMhZu
Content-Disposition: form-data; name="encoding_webm"

on
------WebKitFormBoundaryMFH7A2ecHBQQMhZu
Content-Disposition: form-data; name="encoding_stills"

on
------WebKitFormBoundaryMFH7A2ecHBQQMhZu
Content-Disposition: form-data; name="submit"

Upload and convert
------WebKitFormBoundaryMFH7A2ecHBQQMhZu--
```

![before](https://user-images.githubusercontent.com/16708391/89443146-83bf9780-d76d-11ea-8d17-726cd4e352ae.PNG)


### 🔥 Proof of Fix (PoF) *

Perform the same request again(given in the PoV) and now it doesnt create the `HACKED` file and no code is executed.

![after](https://user-images.githubusercontent.com/16708391/89443282-b36e9f80-d76d-11ea-8f01-d6ae7c939d70.PNG)


### 👍 User Acceptance Testing (UAT)

Only escapeshellcmd() is used, no breaking changes introduced.
